### PR TITLE
Calculate monthly to last sunday date range

### DIFF
--- a/README_redash_query.md
+++ b/README_redash_query.md
@@ -1,0 +1,52 @@
+# Redash Date Parameter Query
+
+## Overview
+This SQL query creates a dynamic date range for Redash that pulls data from the **first day of the current month** to the **most recent Sunday**. This is designed for weekly completeness checks that run on Monday.
+
+## How It Works
+
+### Date Logic
+- **Start Date**: Always the 1st day of the current month
+- **End Date**: The most recent Sunday before today
+  - If today is Sunday: Uses the previous Sunday (7 days ago)
+  - If today is any other day: Calculates back to the most recent Sunday
+
+### Examples
+| Today's Date | Day of Week | Start Date | End Date | Explanation |
+|--------------|-------------|------------|----------|-------------|
+| 9/22/25 | Monday | 9/1/25 | 9/21/25 | Most recent Sunday was yesterday |
+| 9/29/25 | Monday | 9/1/25 | 9/28/25 | Most recent Sunday was yesterday |
+| 9/21/25 | Sunday | 9/1/25 | 9/14/25 | Since today is Sunday, use previous Sunday |
+
+## Files Included
+
+1. **`redash_production_query.sql`** - The main query to use in Redash
+2. **`redash_date_logic_test.sql`** - Test queries to verify the date logic
+3. **`redash_date_query.sql`** - Original detailed version with comments
+
+## Usage in Redash
+
+1. Copy the content from `redash_production_query.sql`
+2. Replace the example section with your actual table and columns:
+   ```sql
+   -- Replace this part:
+   FROM your_table_name yt
+   WHERE yt.your_date_column >= dr.start_date 
+     AND yt.your_date_column <= dr.end_date
+   ```
+3. Add your specific SELECT columns and any additional WHERE conditions
+4. Save as a Redash query
+
+## Key SQL Functions Used
+
+- `DATE_TRUNC('month', CURRENT_DATE)` - Gets first day of current month
+- `EXTRACT(DOW FROM CURRENT_DATE)` - Gets day of week (0=Sunday, 1=Monday, etc.)
+- `INTERVAL` calculations - Subtracts days to find the most recent Sunday
+
+## Database Compatibility
+
+This query uses standard SQL functions that work with:
+- PostgreSQL
+- Most SQL databases supported by Redash
+
+For other databases, you may need to adjust the date functions accordingly.

--- a/business_day_date_logic.sql
+++ b/business_day_date_logic.sql
@@ -1,0 +1,70 @@
+WITH date_parameters AS (
+    SELECT
+        -- Helper: Get the first day of current month
+        DATE_FORMAT(CURDATE(), '%Y-%m-01') AS first_of_current_month,
+        
+        -- Helper: Get the first business day of current month
+        CASE 
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 1 THEN -- First is Sunday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 1 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 7 THEN -- First is Saturday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 2 DAY)
+            ELSE 
+                DATE_FORMAT(CURDATE(), '%Y-%m-01') -- First is a weekday
+        END AS first_business_day_current_month,
+        
+        -- Helper: Get the second business day of current month
+        CASE 
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 1 THEN -- First is Sunday, so 1st biz day is Mon, 2nd is Tue
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 2 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 7 THEN -- First is Saturday, so 1st biz day is Mon, 2nd is Tue
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 3 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 6 THEN -- First is Friday, so 2nd biz day is next Tuesday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 4 DAY)
+            ELSE -- First is Mon-Thu, so 2nd business day is next day
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 1 DAY)
+        END AS second_business_day_current_month
+),
+date_logic AS (
+    SELECT 
+        first_of_current_month,
+        first_business_day_current_month,
+        second_business_day_current_month,
+        
+        -- Check if today is the 1st or 2nd business day of the month
+        CASE 
+            WHEN CURDATE() = first_business_day_current_month 
+                 OR CURDATE() = second_business_day_current_month THEN 1
+            ELSE 0
+        END AS is_first_or_second_biz_day,
+        
+        -- Calculate start date
+        CASE 
+            WHEN CURDATE() = first_business_day_current_month 
+                 OR CURDATE() = second_business_day_current_month THEN 
+                DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL 1 MONTH), '%Y-%m-01') -- First day of previous month
+            ELSE 
+                first_of_current_month -- First day of current month
+        END AS report_start_date,
+        
+        -- Calculate end date
+        CASE 
+            WHEN CURDATE() = first_business_day_current_month 
+                 OR CURDATE() = second_business_day_current_month THEN 
+                LAST_DAY(DATE_SUB(CURDATE(), INTERVAL 1 MONTH)) -- Last day of previous month
+            ELSE 
+                DATE_SUB(CURDATE(), INTERVAL 1 DAY) -- Yesterday
+        END AS report_end_date
+        
+    FROM date_parameters
+)
+
+-- Final selection with the calculated dates
+SELECT 
+    report_start_date,
+    report_end_date,
+    is_first_or_second_biz_day,
+    first_business_day_current_month,
+    second_business_day_current_month,
+    CONCAT('Query will pull data from ', report_start_date, ' through ', report_end_date) as date_info
+FROM date_logic;

--- a/date_logic_explanation.md
+++ b/date_logic_explanation.md
@@ -1,0 +1,63 @@
+# Updated Redash Query - Date Parameter Changes
+
+## What Changed
+
+I've updated your `date_parameters` CTE to automatically calculate the date range instead of using manual parameters:
+
+### Before (Manual Parameters):
+```sql
+WITH date_parameters AS (
+    SELECT
+        CAST('{{Month Start}}' AS DATE) AS report_start_date,
+        CAST('{{End Date}}' AS DATE) AS report_end_date
+),
+```
+
+### After (Dynamic Calculation):
+```sql
+WITH date_parameters AS (
+    SELECT
+        -- Start date: First day of current month
+        DATE_FORMAT(CURDATE(), '%Y-%m-01') AS report_start_date,
+        
+        -- End date: Most recent Sunday
+        -- If today is Sunday (DAYOFWEEK = 1), use the previous Sunday
+        -- Otherwise, calculate days back to most recent Sunday
+        CASE 
+            WHEN DAYOFWEEK(CURDATE()) = 1 THEN -- Today is Sunday
+                DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            ELSE 
+                DATE_SUB(CURDATE(), INTERVAL (DAYOFWEEK(CURDATE()) - 1) DAY)
+        END AS report_end_date
+),
+```
+
+## How It Works
+
+### MySQL Date Functions Used:
+- `CURDATE()` - Gets current date
+- `DATE_FORMAT(CURDATE(), '%Y-%m-01')` - First day of current month
+- `DAYOFWEEK(CURDATE())` - Day of week (1=Sunday, 2=Monday, etc.)
+- `DATE_SUB()` - Subtracts intervals from dates
+
+### Logic for Most Recent Sunday:
+- **If today is Sunday (DAYOFWEEK = 1)**: Go back 7 days to previous Sunday
+- **If today is any other day**: Calculate days back to most recent Sunday using `(DAYOFWEEK(CURDATE()) - 1)`
+
+### Examples:
+| Today's Date | Day of Week | DAYOFWEEK() | Days to Subtract | Result |
+|--------------|-------------|-------------|------------------|--------|
+| 2025-09-22 | Monday | 2 | 2-1 = 1 | 2025-09-21 (Sunday) |
+| 2025-09-29 | Monday | 2 | 2-1 = 1 | 2025-09-28 (Sunday) |
+| 2025-09-21 | Sunday | 1 | 7 days | 2025-09-14 (Previous Sunday) |
+
+## Benefits
+
+1. **Automatic Updates**: Query runs with current date logic every time
+2. **No Manual Parameters**: Eliminates need to update `{{Month Start}}` and `{{End Date}}` parameters
+3. **Consistent Logic**: Always pulls from first of month to most recent Sunday
+4. **Perfect for Monday Reports**: Since your completeness check runs on Monday, it will always capture through the previous Sunday
+
+## Usage
+
+Simply replace your existing query with the updated version. The rest of your query logic remains exactly the same - only the date parameter calculation has changed.

--- a/final_business_day_query.sql
+++ b/final_business_day_query.sql
@@ -1,0 +1,52 @@
+WITH date_parameters AS (
+    SELECT
+        -- Calculate first business day of current month
+        CASE 
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 1 THEN -- First is Sunday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 1 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 7 THEN -- First is Saturday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 2 DAY)
+            ELSE 
+                DATE_FORMAT(CURDATE(), '%Y-%m-01') -- First is a weekday
+        END AS first_biz_day,
+        
+        -- Calculate second business day of current month
+        CASE 
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 1 THEN -- First is Sunday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 2 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 7 THEN -- First is Saturday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 3 DAY)
+            WHEN DAYOFWEEK(DATE_FORMAT(CURDATE(), '%Y-%m-01')) = 6 THEN -- First is Friday
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 4 DAY)
+            ELSE -- First is Mon-Thu
+                DATE_ADD(DATE_FORMAT(CURDATE(), '%Y-%m-01'), INTERVAL 1 DAY)
+        END AS second_biz_day
+),
+final_dates AS (
+    SELECT 
+        first_biz_day,
+        second_biz_day,
+        
+        -- Start date logic
+        CASE 
+            WHEN CURDATE() IN (first_biz_day, second_biz_day) THEN 
+                DATE_FORMAT(DATE_SUB(CURDATE(), INTERVAL 1 MONTH), '%Y-%m-01') -- Previous month start
+            ELSE 
+                DATE_FORMAT(CURDATE(), '%Y-%m-01') -- Current month start
+        END AS report_start_date,
+        
+        -- End date logic
+        CASE 
+            WHEN CURDATE() IN (first_biz_day, second_biz_day) THEN 
+                LAST_DAY(DATE_SUB(CURDATE(), INTERVAL 1 MONTH)) -- Previous month end
+            ELSE 
+                DATE_SUB(CURDATE(), INTERVAL 1 DAY) -- Yesterday
+        END AS report_end_date
+        
+    FROM date_parameters
+)
+
+SELECT 
+    report_start_date,
+    report_end_date
+FROM final_dates

--- a/redash_date_logic_test.sql
+++ b/redash_date_logic_test.sql
@@ -1,0 +1,51 @@
+-- Testing the date logic for Redash query
+-- Example 1: Today is 9/22/25 (Monday) - should return 9/1/25 to 9/21/25
+-- Example 2: Today is 9/29/25 (Monday) - should return 9/1/25 to 9/28/25
+
+-- Test with 9/22/25 (Monday)
+WITH test_date_1 AS (
+  SELECT '2025-09-22'::DATE AS test_current_date
+),
+date_calc_1 AS (
+  SELECT 
+    test_current_date,
+    DATE_TRUNC('month', test_current_date) AS first_of_month,
+    test_current_date - INTERVAL '1 day' * EXTRACT(DOW FROM test_current_date) AS most_recent_sunday,
+    EXTRACT(DOW FROM test_current_date) AS day_of_week -- 0=Sunday, 1=Monday, etc.
+  FROM test_date_1
+)
+SELECT 
+  'Test 1: 9/22/25 (Monday)' AS test_case,
+  test_current_date,
+  day_of_week,
+  first_of_month AS start_date,
+  most_recent_sunday AS end_date,
+  'Expected: 2025-09-01 to 2025-09-21' AS expected_result
+FROM date_calc_1
+
+UNION ALL
+
+-- Test with 9/29/25 (Monday) 
+SELECT 
+  'Test 2: 9/29/25 (Monday)' AS test_case,
+  '2025-09-29'::DATE AS test_current_date,
+  EXTRACT(DOW FROM '2025-09-29'::DATE) AS day_of_week,
+  DATE_TRUNC('month', '2025-09-29'::DATE) AS start_date,
+  '2025-09-29'::DATE - INTERVAL '1 day' * EXTRACT(DOW FROM '2025-09-29'::DATE) AS end_date,
+  'Expected: 2025-09-01 to 2025-09-28' AS expected_result
+
+UNION ALL
+
+-- Test with a Sunday to verify logic
+SELECT 
+  'Test 3: 9/21/25 (Sunday)' AS test_case,
+  '2025-09-21'::DATE AS test_current_date,
+  EXTRACT(DOW FROM '2025-09-21'::DATE) AS day_of_week,
+  DATE_TRUNC('month', '2025-09-21'::DATE) AS start_date,
+  CASE 
+    WHEN EXTRACT(DOW FROM '2025-09-21'::DATE) = 0 THEN 
+      '2025-09-21'::DATE - INTERVAL '7 days'
+    ELSE 
+      '2025-09-21'::DATE - INTERVAL '1 day' * EXTRACT(DOW FROM '2025-09-21'::DATE)
+  END AS end_date,
+  'Expected: 2025-09-01 to 2025-09-14' AS expected_result;

--- a/redash_date_query.sql
+++ b/redash_date_query.sql
@@ -1,0 +1,53 @@
+-- Redash Query: First of Month to Most Recent Sunday
+-- This query creates a date range from the first day of the current month 
+-- to the most recent Sunday (for weekly completeness checks that run on Monday)
+
+WITH date_calculations AS (
+  SELECT 
+    -- Get the first day of the current month
+    DATE_TRUNC('month', CURRENT_DATE) AS first_of_month,
+    
+    -- Get the most recent Sunday
+    -- If today is Sunday, use yesterday's Sunday
+    -- Otherwise, find the most recent Sunday
+    CASE 
+      WHEN EXTRACT(DOW FROM CURRENT_DATE) = 0 THEN -- Today is Sunday
+        CURRENT_DATE - INTERVAL '7 days'
+      ELSE 
+        CURRENT_DATE - INTERVAL '1 day' * EXTRACT(DOW FROM CURRENT_DATE)
+    END AS most_recent_sunday
+),
+final_dates AS (
+  SELECT 
+    first_of_month,
+    most_recent_sunday,
+    -- Ensure we don't go beyond the current month
+    LEAST(most_recent_sunday, DATE_TRUNC('month', CURRENT_DATE) + INTERVAL '1 month' - INTERVAL '1 day') AS end_date
+  FROM date_calculations
+)
+
+-- Your main query goes here - replace this with your actual data query
+SELECT 
+  fd.first_of_month AS start_date,
+  fd.end_date,
+  -- Example: selecting data within the date range
+  -- Replace 'your_table' and 'date_column' with your actual table and date column
+  /*
+  your_data_column1,
+  your_data_column2
+  FROM your_table yt
+  CROSS JOIN final_dates fd
+  WHERE yt.date_column >= fd.first_of_month 
+    AND yt.date_column <= fd.end_date
+  */
+  
+  -- For demonstration, showing the calculated date range
+  'Data from ' || fd.first_of_month::text || ' to ' || fd.end_date::text AS date_range_info
+FROM final_dates fd;
+
+-- Alternative simpler version (if your database supports these functions):
+/*
+SELECT 
+  DATE_TRUNC('month', CURRENT_DATE) AS start_date,
+  CURRENT_DATE - INTERVAL '1 day' * (EXTRACT(DOW FROM CURRENT_DATE) + CASE WHEN EXTRACT(DOW FROM CURRENT_DATE) = 0 THEN 7 ELSE 0 END) AS end_date
+*/

--- a/redash_production_query.sql
+++ b/redash_production_query.sql
@@ -1,0 +1,43 @@
+-- PRODUCTION REDASH QUERY
+-- Date Range: First of Current Month to Most Recent Sunday
+-- Use this query in Redash for your weekly completeness checks
+
+WITH date_range AS (
+  SELECT 
+    -- Start date: First day of current month
+    DATE_TRUNC('month', CURRENT_DATE) AS start_date,
+    
+    -- End date: Most recent Sunday
+    -- If today is Sunday (DOW = 0), use the previous Sunday
+    -- Otherwise, calculate days back to most recent Sunday
+    CASE 
+      WHEN EXTRACT(DOW FROM CURRENT_DATE) = 0 THEN 
+        CURRENT_DATE - INTERVAL '7 days'
+      ELSE 
+        CURRENT_DATE - INTERVAL '1 day' * EXTRACT(DOW FROM CURRENT_DATE)
+    END AS end_date
+)
+
+-- Replace this section with your actual data query
+SELECT 
+  dr.start_date,
+  dr.end_date,
+  
+  -- Example data selection - replace with your actual columns and table
+  -- Uncomment and modify the following lines for your actual query:
+  /*
+  COUNT(*) as record_count,
+  your_column1,
+  your_column2
+  FROM your_table_name yt
+  CROSS JOIN date_range dr
+  WHERE yt.your_date_column >= dr.start_date 
+    AND yt.your_date_column <= dr.end_date
+  GROUP BY dr.start_date, dr.end_date, your_column1, your_column2
+  ORDER BY your_column1
+  */
+  
+  -- For testing purposes, showing the calculated date range
+  CONCAT('Query will pull data from ', start_date::text, ' through ', end_date::text) as date_info
+
+FROM date_range dr;

--- a/updated_redash_query.sql
+++ b/updated_redash_query.sql
@@ -1,0 +1,183 @@
+WITH date_parameters AS (
+    SELECT
+        -- Start date: First day of current month
+        DATE_FORMAT(CURDATE(), '%Y-%m-01') AS report_start_date,
+        
+        -- End date: Most recent Sunday
+        -- If today is Sunday (DAYOFWEEK = 1), use the previous Sunday
+        -- Otherwise, calculate days back to most recent Sunday
+        CASE 
+            WHEN DAYOFWEEK(CURDATE()) = 1 THEN -- Today is Sunday
+                DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+            ELSE 
+                DATE_SUB(CURDATE(), INTERVAL (DAYOFWEEK(CURDATE()) - 1) DAY)
+        END AS report_end_date
+),
+
+-- Determine the first day of the starting month for month series generation
+first_month_of_report AS (
+    SELECT DATE_FORMAT(dp.report_start_date, '%Y-%m-01') AS first_day_of_start_month
+    FROM date_parameters dp
+),
+
+-- Helper CTE to generate digits 0-9
+digits_0_9 AS (
+    SELECT 0 AS d UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
+    SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9
+),
+
+-- Helper CTE to generate digits 0-11 (used for tens multiplier to get 0-119 for month offsets)
+digits_0_11 AS ( 
+    SELECT 0 AS d UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL
+    SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9 UNION ALL
+    SELECT 10 UNION ALL SELECT 11
+),
+
+-- Generate a sequence of numbers (0 to 119) to be used as month offsets (covers 10 years)
+numbers_sequence AS (
+    SELECT (d1.d + (d2.d * 10)) AS month_offset
+    FROM digits_0_9 d1        -- For the units digit (0-9)
+    CROSS JOIN digits_0_11 d2 -- For the tens place (d2.d * 10 results in 0, 10, ..., 110)
+),
+
+-- Generate a series of the first day of each month within the report date range
+month_series_for_report_points AS (
+    SELECT
+        CAST(DATE_ADD(CAST(fmr.first_day_of_start_month AS DATE), INTERVAL ns.month_offset MONTH) AS DATE) AS current_month_start
+    FROM numbers_sequence ns
+    CROSS JOIN first_month_of_report fmr
+    CROSS JOIN date_parameters dp
+    WHERE
+        DATE_ADD(CAST(fmr.first_day_of_start_month AS DATE), INTERVAL ns.month_offset MONTH) <= dp.report_end_date
+        AND CAST(fmr.first_day_of_start_month AS DATE) <= dp.report_end_date -- Ensure report range itself is valid
+        AND ns.month_offset < 240 -- Consistent with numbers_sequence generation limit (20 years)
+),
+-- select * from month_series_for_report_points where current_month_start >= '2025-01-01'
+
+-- Base CTE for origination accounts
+origination_accounts_base AS (
+    SELECT
+        oa.id AS origination_account_id,
+        CONCAT_WS('-', ob.name, oa.purpose, oa.id) AS origination_account_full
+    FROM origination_accounts AS oa
+    LEFT JOIN origination_banks AS ob ON oa.origination_bank_id = ob.id
+    GROUP BY 1, 2
+),
+
+-- Filter for the specific origination account(s)
+relevant_origination_accounts AS (
+    SELECT
+        oa.origination_account_id,
+        oa.origination_account_full
+    FROM origination_accounts_base AS oa
+    WHERE (oa.origination_account_full in ({{Origination Account}}))
+    -- add parameter back once Platform Accounting confirms this list: https://redash.zp-int.com/queries/121815/source
+    -- https://gustohq.slack.com/archives/C04PT6SPH8Q/p1747870347457469?thread_ts=1747769234.942189&cid=C04PT6SPH8Q
+    -- WHERE oa.origination_account_id in (26, 28, 31) -- Hardcoded for origination_account_id = 26
+    GROUP BY 1, 2
+),
+
+-- report_points_cte defines the "period_label_month_start" and the actual "as_of_date" 
+-- for calculations for each month in the range.
+report_points_cte AS (
+    SELECT
+        ms.current_month_start AS period_label_month_start,
+        CASE
+            -- If the current month in the series is the same month/year as the overall report_end_date
+            WHEN YEAR(ms.current_month_start) = YEAR(dp.report_end_date) AND MONTH(ms.current_month_start) = MONTH(dp.report_end_date)
+            THEN dp.report_end_date -- The 'as of' date is the overall report_end_date
+            ELSE LAST_DAY(ms.current_month_start) -- Otherwise, it's the last day of the current month from the series
+        END AS as_of_date,
+        roa.origination_account_id,
+        roa.origination_account_full
+    FROM month_series_for_report_points ms
+    CROSS JOIN date_parameters dp
+    CROSS JOIN relevant_origination_accounts roa
+    WHERE ms.current_month_start IS NOT NULL -- Ensure month series actually produced rows
+),
+
+-- Collect all BAI2 bank transactions for the specified account
+all_bai2_transactions_for_account AS (
+    SELECT
+        bai.origination_account_id,
+        bai.date AS bai2_bt_dt,
+        CASE
+            WHEN bai.transaction_type = 2 THEN (bai.amount * -1) / 100.00 -- Assumes bai.amount is integer cents; result is precise DECIMAL
+            WHEN bai.transaction_type = 4 THEN bai.amount / 100.00       -- Assumes bai.amount is integer cents; result is precise DECIMAL
+            ELSE NULL
+        END AS bai2_signed_amount, -- This is the precise dollar value for summing
+        bai.created_at AS created_at_utc
+    FROM bank_transactions AS bai
+    JOIN relevant_origination_accounts AS roa ON bai.origination_account_id = roa.origination_account_id
+    JOIN date_parameters dp ON bai.date <= dp.report_end_date -- <<< PRE-FILTER ADDED
+    WHERE bai.transaction_type IN (2, 4)
+),
+
+-- Collect all closing bank balance transactions for the specified account
+all_closing_ledgers_for_account AS (
+    SELECT
+        c.origination_account_id,
+        c.date AS cbb_date,
+        ROUND((c.amount / 100.00), 2) AS closing_ledger_amount, -- Assumes c.amount is integer cents; converted to DECIMAL dollars and rounded
+        c.created_at AS created_at_utc
+    FROM bank_transactions AS c
+    JOIN relevant_origination_accounts AS roa ON c.origination_account_id = roa.origination_account_id
+    JOIN date_parameters dp ON c.date <= dp.report_end_date -- <<< PRE-FILTER ADDED
+    WHERE c.transaction_type = 0
+      AND c.type_description = 'Closing Ledger'
+),
+
+-- Calculate running sum of precise BAI2 dollar transactions UP TO each 'as_of_date'
+running_bai2_sums AS (
+    SELECT
+        rp.period_label_month_start,
+        rp.as_of_date,
+        rp.origination_account_id,
+        SUM(bt.bai2_signed_amount) AS total_bai2_signed_sum_running, -- Sum of precise DECIMAL dollar values
+        MAX(bt.created_at_utc) AS max_bai2_bt_created_utc_running
+    FROM report_points_cte rp
+    LEFT JOIN all_bai2_transactions_for_account bt
+        ON rp.origination_account_id = bt.origination_account_id
+        AND bt.bai2_bt_dt <= rp.as_of_date
+    GROUP BY rp.period_label_month_start, rp.as_of_date, rp.origination_account_id -- Group by all unique fields of a report point
+),
+
+-- Determine the latest closing bank balance ON OR BEFORE each 'as_of_date'
+latest_closing_ledgers AS (
+    SELECT
+        rp.period_label_month_start,
+        rp.as_of_date,
+        rp.origination_account_id,
+        cl.closing_ledger_amount, -- This is already rounded to 2 decimal places
+        cl.cbb_date AS closing_ledger_actual_date,
+        cl.created_at_utc AS closing_ledger_created_utc,
+        ROW_NUMBER() OVER (
+            PARTITION BY rp.period_label_month_start, rp.as_of_date, rp.origination_account_id -- Partition by all unique fields of a report point
+            ORDER BY cl.cbb_date DESC, cl.created_at_utc DESC
+        ) as rn
+    FROM report_points_cte rp
+    LEFT JOIN all_closing_ledgers_for_account cl
+        ON rp.origination_account_id = cl.origination_account_id
+        AND cl.cbb_date <= rp.as_of_date
+)
+
+-- Final selection combining data for each report point
+SELECT
+    rp.period_label_month_start AS month_start,
+    rp.as_of_date AS end_date, -- This is the 'as_of_date' used for calculations
+    -- rp.origination_account_id,
+    rp.origination_account_full, -- for readability, e.g. Grasshopper-operations-31
+    ROUND(rbs.total_bai2_signed_sum_running, 2) AS bai2_sum, -- Sum is rounded here
+    lcl.closing_ledger_amount AS closing_bank_balance, -- Already rounded in its CTE
+    (ROUND(COALESCE(rbs.total_bai2_signed_sum_running, 0.00), 2) - COALESCE(lcl.closing_ledger_amount, 0.00)) AS signed_variance,
+    ABS((ROUND(COALESCE(rbs.total_bai2_signed_sum_running, 0.00), 2) - COALESCE(lcl.closing_ledger_amount, 0.00))) AS absolute_variance,
+    CONVERT_TZ(rbs.max_bai2_bt_created_utc_running, 'UTC', 'America/Los_Angeles') AS max_bai2_bt_created_pt,
+    CONVERT_TZ(lcl.closing_ledger_created_utc, 'UTC', 'America/Los_Angeles') AS closing_bank_balance_created_pt
+FROM report_points_cte rp
+LEFT JOIN running_bai2_sums rbs
+    ON rp.period_label_month_start = rbs.period_label_month_start AND rp.as_of_date = rbs.as_of_date AND rp.origination_account_id = rbs.origination_account_id
+LEFT JOIN latest_closing_ledgers lcl
+    ON rp.period_label_month_start = lcl.period_label_month_start AND rp.as_of_date = lcl.as_of_date AND rp.origination_account_id = lcl.origination_account_id AND lcl.rn = 1
+WHERE 1=1
+AND (rbs.total_bai2_signed_sum_running IS NOT NULL OR lcl.closing_ledger_amount IS NOT NULL) -- Only include rows if there's BAI2 sum data and/or bank balance data
+ORDER BY rp.origination_account_id ASC, rp.period_label_month_start DESC


### PR DESCRIPTION
Update Redash query to dynamically set date parameters from the first of the month to the most recent Sunday.

This change automates the date range for weekly completeness checks, ensuring the query always covers data from the current month's start up to the Sunday immediately preceding the run date, eliminating manual parameter updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-d322af5a-0c01-461c-b224-d28d971311bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d322af5a-0c01-461c-b224-d28d971311bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

